### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Next 2E
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ Message Claire on facebook if you want to be added to our chat, or you can [subm
 - elizdet
 - eman17
 - bstern
+
+## License
+The code used in this repository is licensed under the `MIT License`. All
+other media used on the website, located under the  `img/` directory, have
+their rights reserved.


### PR DESCRIPTION
This PR licenses the code for the 2E website under the `MIT License`, to allow for future 2E residents and others to do with the code as they please within the bounds of the license. The media on this website, located under the `img/` directory, is exempted from this license, and their rights are reserved.

This PR closes #14.